### PR TITLE
Add convertPainTextHTMLLinkIntoMarkdownReferenceFlag to turn on/off c…

### DIFF
--- a/Application/GBAppledocApplication.m
+++ b/Application/GBAppledocApplication.m
@@ -269,6 +269,7 @@ static char *kGBArgHelp = "help";
         { kGBArgDocSetXMLFilename,                                          0,      DDGetoptRequiredArgument },
 		{ kGBArgDocSetPackageFilename,										0,		DDGetoptRequiredArgument },
 		
+        { "no-covert-pain-text-html", 0, DDGetoptNoArgument},
 		{ kGBArgCleanOutput,												0,		DDGetoptNoArgument },
 		{ kGBArgCreateHTML,													'h',	DDGetoptNoArgument },
 		{ kGBArgCreateDocSet,												'd',	DDGetoptNoArgument },
@@ -840,6 +841,12 @@ static char *kGBArgHelp = "help";
 - (void)setNoPrefixMergedSections:(BOOL)value { self.settings.prefixMergedCategoriesSectionsWithCategoryName = !value; }
 - (void)setUseCodeOrder:(BOOL)value { self.settings.useCodeOrder = value; }
 - (void)setNoUseCodeOrder:(BOOL)value { self.settings.useCodeOrder = !value; }
+
+- (void)setNoCovertPainTextHtml:(BOOL)value {
+
+    self.settings.convertPainTextHTMLLinkIntoMarkdownReference = NO;
+
+}
 
 - (void)setWarnMissingOutputPath:(BOOL)value { self.settings.warnOnMissingOutputPathArgument = value; }
 - (void)setWarnMissingCompanyId:(BOOL)value { self.settings.warnOnMissingCompanyIdentifier = value; }

--- a/Application/GBApplicationSettingsProvider.h
+++ b/Application/GBApplicationSettingsProvider.h
@@ -422,6 +422,12 @@ NSString *NSStringFromGBPublishedFeedFormats(GBPublishedFeedFormats format);
 @property (assign) int exitCodeThreshold;
 
 ///---------------------------------------------------------------------------------------
+/// @name coress References handling
+///---------------------------------------------------------------------------------------
+
+@property (assign) BOOL convertPainTextHTMLLinkIntoMarkdownReference;
+
+///---------------------------------------------------------------------------------------
 /// @name Warnings handling
 ///---------------------------------------------------------------------------------------
 

--- a/Application/GBApplicationSettingsProvider.m
+++ b/Application/GBApplicationSettingsProvider.m
@@ -155,6 +155,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(GBApplicationSettingsProvider, sharedApplicationS
 		self.embedCrossReferencesWhenProcessingMarkdown = YES;
 		self.embedAppledocBoldMarkersWhenProcessingMarkdown = YES;
 
+        self.convertPainTextHTMLLinkIntoMarkdownReference = YES;   
 		self.warnOnMissingOutputPathArgument = YES;
 		self.warnOnMissingCompanyIdentifier = YES;
 		self.warnOnUndocumentedObject = YES;

--- a/Processing/GBCommentsProcessor.m
+++ b/Processing/GBCommentsProcessor.m
@@ -878,6 +878,12 @@ typedef NSUInteger GBProcessingFlag;
 		result = [NSString stringWithFormat:@"[`%@`](%@)", description, address];
 	else
 		result = [NSString stringWithFormat:@"[%@](%@)", description, address];
+    
+    if (!self.settings.convertPainTextHTMLLinkIntoMarkdownReference && [description isEqualToString:address] &&([description hasPrefix:@"http://"] || [description hasPrefix:@"https://"]))
+    {
+        return description;;
+    }
+    
 	return [self.settings stringByEmbeddingCrossReference:result];
 }
 


### PR DESCRIPTION
…onverting paint text HTML Link to Markdown reference.

To turn off it. just Add `--no-covert-pain-text-html` into argument.
